### PR TITLE
spot_wrapper submodule changed from ssh to https source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spot_wrapper"]
 	path = spot_wrapper
-	url = git@github.com:bdaiinstitute/spot_wrapper
+	url = https://github.com/bdaiinstitute/spot_wrapper.git


### PR DESCRIPTION
With this change you don't have to add an ssh key to be able to pull the public submodule.